### PR TITLE
Require manual input/output folders instead of demo defaults

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -2,10 +2,10 @@
 # MAKE SURE NAMES AND INPUTS ARE SEPARATED WITH ": " [colon-spacebar]
 
 # These paths are relative to this configuration file so the launcher works from any location.
-analysis_directory: demo/input
+analysis_directory:
 
 # This is the folder which will save all results into
-output_directory: demo/output
+output_directory:
 
 --------------------------------------------------------------------------------------------------------
 

--- a/gui/config_editor.py
+++ b/gui/config_editor.py
@@ -275,6 +275,7 @@ class ConfigEditor(QWidget):
         config = validate_config(
             self._template_values(),
             check_analysis_directory=False,
+            require_directories=False,
         )
         self.set_config(config)
 
@@ -284,6 +285,8 @@ class ConfigEditor(QWidget):
         values = parse_config(self.template_path)
         template_root = self.template_path.expanduser().resolve().parent
         for key in ("analysis_directory", "output_directory"):
+            if not values[key]:
+                continue
             path = Path(values[key]).expanduser()
             if not path.is_absolute():
                 values[key] = str((template_root / path).resolve())
@@ -301,16 +304,22 @@ class ConfigEditor(QWidget):
                 widget.valueChanged.connect(self._validate_inline)
 
     def _update_path_status(self, key: str, line_edit: QLineEdit) -> None:
-        path = Path(line_edit.text().strip()).expanduser()
         has_value = bool(line_edit.text().strip())
-        valid = path.is_dir() if key == "analysis_directory" else has_value
+        path = Path(line_edit.text().strip()).expanduser()
+        valid = has_value and path.is_dir() if key == "analysis_directory" else has_value
         line_edit.setProperty("invalid", not valid)
         line_edit.style().unpolish(line_edit)
         line_edit.style().polish(line_edit)
         if key == "analysis_directory":
-            status = "Folder found" if valid else "Choose an existing folder"
+            if not has_value:
+                status = "Choose a folder"
+            else:
+                status = "Folder found" if valid else "Choose an existing folder"
         else:
-            status = "Folder found" if path.is_dir() else "Will be created"
+            if not has_value:
+                status = "Choose a folder"
+            else:
+                status = "Folder found" if path.is_dir() else "Will be created"
         self.path_status_labels[key].setText(status)
         self.path_status_labels[key].setProperty("valid", valid)
         self._validate_inline()

--- a/octolyzer/config_loader.py
+++ b/octolyzer/config_loader.py
@@ -180,8 +180,14 @@ def validate_config(
     values: Mapping[str, object] | Config,
     *,
     check_analysis_directory: bool = True,
+    require_directories: bool = True,
 ) -> Config:
-    """Validate raw configuration values and return a typed ``Config``."""
+    """Validate raw configuration values and return a typed ``Config``.
+
+    ``require_directories`` can be set to ``False`` to allow ``analysis_directory``
+    and ``output_directory`` to be blank, e.g. when building the initial, unset
+    state of the configuration editor rather than validating a run-ready config.
+    """
     if isinstance(values, Config):
         raw_values = values.as_values()
     else:
@@ -198,7 +204,7 @@ def validate_config(
     directory_values: dict[str, str] = {}
     for key in DIRECTORY_KEYS:
         value = str(raw_values[key]).strip()
-        if not value:
+        if not value and require_directories:
             errors.append(f"'{key}' cannot be empty.")
         directory_values[key] = value
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -85,11 +85,11 @@ class GuiWidgetTests(unittest.TestCase):
         self.assertEqual(editor.widgets["choroid_measure_type"].currentText(), "perpendicular")
         editor.deleteLater()
 
-    def test_template_paths_are_relative_to_octolyzer_root(self):
+    def test_template_paths_are_empty_by_default(self):
         editor = ConfigEditor(Path("config.txt"))
 
-        self.assertEqual(editor.values()["analysis_directory"], str(Path.cwd() / "demo" / "input"))
-        self.assertEqual(editor.values()["output_directory"], str(Path.cwd() / "demo" / "output"))
+        self.assertEqual(editor.values()["analysis_directory"], "")
+        self.assertEqual(editor.values()["output_directory"], "")
         editor.deleteLater()
 
     def test_config_editor_uses_compact_map_control_and_inline_path_validation(self):
@@ -123,7 +123,15 @@ class GuiWidgetTests(unittest.TestCase):
         self.assertEqual(window.discovery_thread, None)
         self.assertGreater(len(window.candidates), 0)
         self.assertNotIn("|", window.environment_combo.currentText())
-        self.assertTrue(window.run_button.isEnabled())
+        # Input/output folders are blank by default, so the run button stays
+        # disabled until the user fills in both paths.
+        self.assertFalse(window.run_button.isEnabled())
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            window.config_editor.widgets["analysis_directory"].line_edit.setText(temporary_directory)
+            output_directory = str(Path(temporary_directory) / "output")
+            window.config_editor.widgets["output_directory"].line_edit.setText(output_directory)
+            self.application.processEvents()
+            self.assertTrue(window.run_button.isEnabled())
         self.assertEqual(window.main_splitter.orientation(), Qt.Orientation.Horizontal)
         window.resize(1440, 760)
         window.show()
@@ -152,11 +160,17 @@ class GuiWidgetTests(unittest.TestCase):
             loop.exec()
         self.application.processEvents()
 
-        window.current_probe = None
-        window._config_valid = True
-        window._update_ready_state()
-        with patch.object(window, "check_environment") as check_environment:
-            window.run_analysis()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            window.config_editor.widgets["analysis_directory"].line_edit.setText(temporary_directory)
+            output_directory = str(Path(temporary_directory) / "output")
+            window.config_editor.widgets["output_directory"].line_edit.setText(output_directory)
+            self.application.processEvents()
+
+            window.current_probe = None
+            window._config_valid = True
+            window._update_ready_state()
+            with patch.object(window, "check_environment") as check_environment:
+                window.run_analysis()
 
         check_environment.assert_called_once_with()
         self.assertTrue(window._run_after_environment_check)


### PR DESCRIPTION
- config.txt ships with blank analysis_directory/output_directory instead of demo/input and demo/output.
- ConfigEditor no longer resolves an empty path into the app's runtime directory (Path("") resolves to "."), and its reset() builds the initial blank state without raising ConfigError.
- validate_config() gains a require_directories flag so the editor's blank startup config can be constructed while Save/Run still require both folders to be filled in.
- Path status labels no longer misreport an empty field as "Folder found" (Path("").is_dir() is True).
- Updated GUI tests to reflect blank defaults and a Run button that stays disabled until both folders are populated.